### PR TITLE
Include fixes from zotero/make-it-red

### DIFF
--- a/bootstrap.js
+++ b/bootstrap.js
@@ -31,6 +31,7 @@ async function waitForZotero() {
 	while (windows.hasMoreElements()) {
 		let win = windows.getNext();
 		if (win.Zotero) {
+			Zotero = win.Zotero;
 			found = true;
 			break;
 		}
@@ -56,6 +57,7 @@ async function waitForZotero() {
 		});
 	}
 	await Zotero.initializationPromise;
+	return;
 }
 
 async function install() {
@@ -127,5 +129,11 @@ function shutdown() {
 }
 
 function uninstall() {
+	// `Zotero` object isn't available in `uninstall()` in Zotero 6, so log manually
+	if (typeof Zotero == 'undefined') {
+		dump("LIDIA: Uninstalled\n\n");
+		return;
+	}
+
 	log("Uninstalled");
 }

--- a/lib.js
+++ b/lib.js
@@ -1,4 +1,9 @@
 if (!Zotero.Lidia) {
+	// Global properties are imported in Zotero 6 and included automatically in Zotero 7
+	if (Zotero.platformMajorVersion < 102) {
+		// Cu.importGlobalProperties(['URL']);
+	}
+
 	Zotero.Lidia = {
 		log(msg) {
 			Zotero.debug("LIDIA: " + msg);


### PR DESCRIPTION
- Properly assign Zotero object on bootstrap re-enable in Zotero 6
- Return after awaiting initialization promise if Zotero object exists
- Example of importing global/window property
- Zotero object isn't available in uninstall() in Zotero 6