### PR TITLE
Only allow editing editable annotations

### DIFF
--- a/lib.js
+++ b/lib.js
@@ -70,7 +70,7 @@ if (!Zotero.Lidia) {
             /* Disable the panel after a tab is selected, because the user
              * first has to select an annotation. It would be better if
              * the selected annotation was automatically activated. */
-            Zotero.Lidia.Panel.disablePanel(true);
+            Zotero.Lidia.Panel.disablePanel(undefined);
         },
     };
 }


### PR DESCRIPTION
* Disable importing if annotation is not editable (owned by another user) or external (part of the PDF)
* Disable editing if annotation is not editable

Closes #15 