### PR TITLE
Fill in language field with iso-639-3 codes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,6 +6,7 @@
         "": {
             "hasInstallScript": true,
             "dependencies": {
+                "iso-639-3": "^3.0.1",
                 "react": "^18.2.0",
                 "react-dom": "^18.2.0"
             },
@@ -669,6 +670,15 @@
             "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
             "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
             "dev": true
+        },
+        "node_modules/iso-639-3": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/iso-639-3/-/iso-639-3-3.0.1.tgz",
+            "integrity": "sha512-SdljCYXOexv/JmbQ0tvigHN43yECoscVpe2y2hlEqy/CStXQlroPhZLj7zKLRiGqLJfw8k7B973UAMDoQczVgQ==",
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/wooorm"
+            }
         },
         "node_modules/js-tokens": {
             "version": "4.0.0",
@@ -1389,6 +1399,11 @@
             "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
             "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
             "dev": true
+        },
+        "iso-639-3": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/iso-639-3/-/iso-639-3-3.0.1.tgz",
+            "integrity": "sha512-SdljCYXOexv/JmbQ0tvigHN43yECoscVpe2y2hlEqy/CStXQlroPhZLj7zKLRiGqLJfw8k7B973UAMDoQczVgQ=="
         },
         "js-tokens": {
             "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
         "patch-package": "^6.2.2"
     },
     "dependencies": {
+        "iso-639-3": "^3.0.1",
         "react": "^18.2.0",
         "react-dom": "^18.2.0"
     }

--- a/src/components/AnnotationForm.js
+++ b/src/components/AnnotationForm.js
@@ -1,7 +1,21 @@
 import React from 'react';
 import { useState } from "react";
+import { iso6393 } from "iso-639-3";
+
+let languageList = [];
+function getLanguageList() {
+    if (languageList.length > 0) {
+        return languageList;
+    } else {
+        languageList = iso6393.filter(
+            (obj) => { return obj.type === 'living' && typeof obj.iso6391 !== 'undefined' }
+        ).map(({ name, iso6393 }) => [iso6393, name]);
+        return languageList;
+    }
+}
 
 function AnnotationForm(props) {
+    log(getLanguageList()[0]);
     // argname: lidiaArgumentName.label
     // linglevel: lidiaLinguisticLevel.label
     // arglang: lidiaArgumentLanguage.label
@@ -45,6 +59,11 @@ function AnnotationForm(props) {
         width: '92%',
     }
 
+    const languageRows = [(<option value="">(undefined)</option>)];
+    for (language of getLanguageList()) {
+        languageRows.push(<option value={language[0]}>{language[0]} – {language[1]}</option>);
+    }
+
     return (
         <div style={divStyle}>
 
@@ -80,14 +99,12 @@ function AnnotationForm(props) {
                             </div>
 
                             <div style={labelStyle}>
-                                <label htmlFor="arglang">Language:</label>
+                                <label htmlFor="arglang" style={fullWidthStyle}>Language:</label>
                             </div>
 
                             <div>
                                 <select name="arglang" value={lidiaFields.arglang} onChange={handleChange} >
-                                    <option value="">(undefined)</option>
-                                    <option value="en">English</option>
-                                    <option value="nl">Dutch</option>
+                                    {languageRows}
                                 </select>
                             </div>
 


### PR DESCRIPTION
Maybe not yet finished, but this might do for now. This gives a selection of iso-639-3 codes in a default HTML combo box. The user can quickly select one by typing the letters of the required language, such as `nld` for Dutch. Only languages are selected that are `living` and that have a two-character iso-639-1 code as well (in practice the bigger languages). That may cause problems at some point, but including all languages makes the form very slow...