### PR TITLE
Multiple terms

### DIFF
--- a/src/components/AnnotationForm.js
+++ b/src/components/AnnotationForm.js
@@ -46,8 +46,8 @@ const AnnotationForm = (props) => {
         pagestart: props.data.pagestart,
         pageend: props.data.pageend,
         argname: props.data.argname,
-        linglevel: props.data.linglevel,
         lexiconterm: props.data.lexiconterm,
+        otherterm: props.data.otherterm,
         customterm: props.data.customterm,
         arglang: props.data.arglang,
         description: props.data.description,
@@ -123,9 +123,14 @@ const AnnotationForm = (props) => {
     }
 
     const handleLexiconTermChange = (data) => {
-        log('Change!\n' + JSON.stringify(data));
         setLidiaFields((prevState) => {
             return { ...prevState, "lexiconterm": data}
+        });
+    }
+
+    const handleOtherTermChange = (data) => {
+        setLidiaFields((prevState) => {
+            return { ...prevState, "otherterm": data}
         });
     }
 
@@ -255,7 +260,10 @@ const AnnotationForm = (props) => {
                                 <label>Other terms:</label>
                             </div>
 
-                            <LexiconTermList />
+                            <LexiconTermField
+                              value={getValue('otherterm')}
+                              onChange={handleOtherTermChange}
+                            />
 
                         </div>
 

--- a/src/components/AnnotationForm.js
+++ b/src/components/AnnotationForm.js
@@ -2,6 +2,9 @@ import React from 'react';
 import { useState } from "react";
 import { iso6393 } from "iso-639-3";
 
+import LexiconTermField from './LexiconTermField';
+import LexiconTermList from './LexiconTermList';
+
 let languageList = [];
 function getLanguageList() {
     if (languageList.length > 0) {
@@ -84,6 +87,11 @@ const AnnotationForm = (props) => {
         // (which will be discarded when saving), but the value of the
         // previous annotation, so that the user sees which annotation is
         // being continued
+
+        if (field === 'lexiconterm') {
+            log('Lexicon term in annotation form: ' + lidiaFields[field])
+            log(JSON.stringify(props.data));
+        }
         if (!lidiaFields.argcont) {
             return lidiaFields[field];
         } else {
@@ -111,6 +119,13 @@ const AnnotationForm = (props) => {
     const handleToggleContinuation = (event) => {
         setLidiaFields((prevState) => {
             return { ...prevState, "argcont": event.target.checked}
+        });
+    }
+
+    const handleLexiconTermChange = (data) => {
+        log('Change!\n' + JSON.stringify(data));
+        setLidiaFields((prevState) => {
+            return { ...prevState, "lexiconterm": data}
         });
     }
 
@@ -207,32 +222,10 @@ const AnnotationForm = (props) => {
                                 </select>
                             </div>
 
-                            <div>
-
-                            </div>
-                            <div style={{margin: "5px"}}>
-                                <label style={{display: "block"}} htmlFor="lexiconterm">Lexicon term</label>
-                                <select style={{margin: "0 5px 0 0"}} value={lexiconTermSubfield} onChange={onLexiconTermSubfieldChange}>
-                                    {subfields.map((subfield) => (
-                                        <option key={subfield} value={subfield}>
-                                            {subfield}
-                                        </option>
-                                        ))
-                                    }
-                                </select>
-                                <select name="lexiconterm" value={getValue("lexiconterm") || null} onChange={handleChange}>
-                                    {filteredLexiconTerms.map((option) => (
-                                        <option key={option.key} value={option.lemma}>
-                                            {option.term}
-                                        </option>
-                                    ))}
-                                </select>
-                            </div>
-
-                            <div>
-                                <label htmlFor="customterm" style={{marginTop: '5px'}}>Custom term:</label>
-                                <input type="text" style={fullWidthStyle} name="customterm" value={getValue("customterm")} onChange={handleChange} />
-                            </div>
+                            <LexiconTermField
+                              value={getValue('lexiconterm')}
+                              onChange={handleLexiconTermChange}
+                            />
 
                             <div style={labelStyle}>
                                 <label htmlFor="description">Short description:</label>
@@ -257,6 +250,7 @@ const AnnotationForm = (props) => {
                                     {annotationRefRows}
                                 </select>
                             </div>
+
                         </div>
 
 

--- a/src/components/AnnotationForm.js
+++ b/src/components/AnnotationForm.js
@@ -251,6 +251,12 @@ const AnnotationForm = (props) => {
                                 </select>
                             </div>
 
+                            <div style={labelStyle}>
+                                <label>Other terms:</label>
+                            </div>
+
+                            <LexiconTermList />
+
                         </div>
 
 

--- a/src/components/LexiconTermField.js
+++ b/src/components/LexiconTermField.js
@@ -1,0 +1,99 @@
+import React, { useState, useEffect } from 'react';
+
+// This works because we're using esbuild?
+// Note: a SQLite file would be ~2.5 times smaller than this JSON
+import lexiconOfLinguistics from './lexiconTerms.json';
+
+const LexiconTermField = (props) => {
+    log("Props: \n" + JSON.stringify(props, space=2));
+    // TODO: ungroup the subfields and duplicate terms across individual subfields
+    const linguisticLevels = ["", "All", "Syntax","Phonetics","Morphology","Phonology","Semantics","General","Phonology; Phonetics","Morphology; Syntax","Phonology; Morphology","Syntax; Semantics","Morphology; Semantics"];
+    log(JSON.stringify(props.value));
+    const [linguisticLevel, setLinguisticLevel] = useState(
+        props.value.linglevel
+    );
+    const [filteredLexiconTerms, setFilteredLexiconTerms] = useState(
+        lexiconOfLinguistics
+    );
+    const [lexiconTerm, setLexiconTerm] = useState(
+        props.value.lexiconterm
+    );
+    const [customTerm, setCustomTerm] = useState(
+        props.value.customterm
+    );
+
+    useEffect(() => {
+        props.onChange({
+            linglevel: linguisticLevel,
+            lexiconterm: lexiconTerm,
+            customterm: customTerm
+        });
+    }, [linguisticLevel, lexiconTerm, customTerm]);
+
+    useEffect(() => {
+        setLinguisticLevel(props.value.linglevel);
+        setLexiconTerm(props.value.lexiconterm);
+        setCustomTerm(props.value.customterm);
+    }, [props.value]);
+
+    const labelStyle = {
+        marginTop: '5px',
+    }
+
+    const fullWidthStyle = {
+        width: '92%',
+    }
+
+    const handleLinguisticLevelSelect  = (event) => {
+        setLinguisticLevel(event.target.value);
+        if (event.target.value === "All") {
+            setFilteredLexiconTerms(lexiconOfLinguistics);
+        } else {
+            const _filteredLexiconTerms = lexiconOfLinguistics.filter(
+                (lexiconterm) => {
+                    return lexiconterm.subfield === event.target.value;
+                }
+            );
+            setFilteredLexiconTerms(_filteredLexiconTerms);
+        }
+    }
+
+    const handleLexiconTermSelect = (event) => {
+        setLexiconTerm(event.target.value);
+    }
+
+    const handleCustomTermChange = (event) => {
+        setCustomTerm(event.target.value);
+    }
+
+    return (
+        <div>
+            <div style={{margin: "5px"}}>
+                <label style={{display: "block"}} htmlFor="linglevel">Linguistic level</label>
+                <select style={{margin: "0 5px 0 0"}} value={linguisticLevel || null} onChange={handleLinguisticLevelSelect}>
+                    {linguisticLevels.map((subfield) => (
+                        <option key={subfield} value={subfield}>
+                            {subfield}
+                        </option>
+                        ))
+                    }
+                </select>
+                <label style={{display: "block"}} htmlFor="lexiconterm">Lexicon term</label>
+                <select name="lexiconterm" value={lexiconTerm || null} onChange={handleLexiconTermSelect}>
+                    {filteredLexiconTerms.map((option) => (
+                        <option key={option.key} value={option.lemma}>
+                            {option.term}
+                        </option>
+                    ))}
+                </select>
+            </div>
+
+            <div>
+                <label htmlFor="customterm" style={{marginTop: '5px'}}>Custom term:</label>
+                <input type="text" style={fullWidthStyle} name="customterm" value={customTerm} onChange={handleCustomTermChange} />
+            </div>
+        </div>
+    )
+}
+
+export default LexiconTermField;

--- a/src/components/LexiconTermList.js
+++ b/src/components/LexiconTermList.js
@@ -1,0 +1,21 @@
+import React, { useState, useEffect } from 'react';
+
+import LexiconTermField from './LexiconTermField';
+
+const LexiconTermList = (props) => {
+    const lexiconTerms = [
+        { linglevel: 'Syntax', lexiconterm: 'A-position', customterm: '' }
+    ]
+
+    const lexiconTermItems = lexiconTerms.map((lexiconTerm) => {
+        return <LexiconTermField value={lexiconTerm} onChange={() => {}} />
+    });
+
+    return (
+        <div>
+            { lexiconTermItems }
+        </div>
+    );
+}
+
+export default LexiconTermList;

--- a/src/components/LexiconTermList.js
+++ b/src/components/LexiconTermList.js
@@ -3,17 +3,33 @@ import React, { useState, useEffect } from 'react';
 import LexiconTermField from './LexiconTermField';
 
 const LexiconTermList = (props) => {
-    const lexiconTerms = [
-        { linglevel: 'Syntax', lexiconterm: 'A-position', customterm: '' }
-    ]
-
-    const lexiconTermItems = lexiconTerms.map((lexiconTerm) => {
-        return <LexiconTermField value={lexiconTerm} onChange={() => {}} />
+    const [terms, setTerms] = useState([]);
+//    log(terms); <- terms is undefined
+    const lexiconTermItems = terms.map((lexiconTerm) => {
+        return <LexiconTermField
+            value={lexiconTerm}
+            onChange={() => {
+                // Nog in te vullen
+                ;
+            }}
+        />
     });
+
+    const addTermHandler = () => {
+        setTerms((prevState) => {
+            const newItem = {
+                linglevel: '',
+                lexiconterm: '',
+                customterm: ''
+            };
+            return [...prevState, newItem]
+        });
+    }
 
     return (
         <div>
             { lexiconTermItems }
+            <button onClick={addTermHandler()}>Add Term</button>
         </div>
     );
 }

--- a/src/lib.js
+++ b/src/lib.js
@@ -10,10 +10,9 @@ window.Lidia = {
         , {"id": "argname", "label": "lidiaArgumentName.label"}
         , {"id": "pagestart", "label": "lidiaPageStart.label"}
         , {"id": "pageend", "label": "lidiaPageEnd.label"}
-        , {"id": "linglevel", "label": "lidiaLinguisticLevel.label"}
         , {"id": "arglang", "label": "lidiaArgumentLanguage.label"}
-        , {"id": "articleterm", "label": "lidiaArticleTerm.label"}
         , {"id": "lexiconterm", "label": "lidiaLexiconTerm.label"}
+        , {"id": "otherterm", "label": "lidiaLexiconTerm.label"}
         , {"id": "description","label": "lidiaArgumentDescription.label"}
         , {"id": "relationType","label": "lidiaArgumentDescription.label"}
         , {"id": "relationTo","label": "lidiaArgumentDescription.label"}

--- a/src/serialize.js
+++ b/src/serialize.js
@@ -42,9 +42,22 @@ export function deserialize(text) {
         lidiaObject = parse(text.slice("~~~~LIDIA~~~~\n".length));
     }
     if (typeof lidiaObject !== "undefined") {
-        // If there are missing fields, assign an empty string to them
+        // If there are missing fields, give them initial empty values
+        // This is necessary because fields have been added
         for (const fieldId of fieldIds) {
-            if (typeof lidiaObject[fieldId] === "undefined") {
+            log(fieldId + ': ' + lidiaObject[fieldId]);
+            if (
+                (fieldId === "lexiconterm" || fieldId === "otherterm") &&
+                (lidiaObject[fieldId] === "" ||
+                typeof lidiaObject[fieldId] === "undefined")
+            ) {
+                lidiaObject[fieldId] = {
+                    linglevel: "",
+                    lexiconterm: "",
+                    customterm: ""
+                };
+                log('Leeggemaakt.');
+            } else if (typeof lidiaObject[fieldId] === "undefined") {
                 lidiaObject[fieldId] = '';
             }
         }
@@ -60,11 +73,8 @@ export function deserialize(text) {
  * @return {Object} - the empty LIDIA JavaScript object
  */
 export function getEmptyAnnotation() {
-    const fieldIds = Lidia.fields.map(obj => obj.id);
-    const data = {};
-    for (const fieldId of fieldIds) {
-        data[fieldId] = '';
-    }
+    const data = deserialize(serialize({}));
+    log("Created empty annotation data:\n" + JSON.stringify(data));
     return data;
 }
 


### PR DESCRIPTION
- What name do we want to have for the fields? Currently `lexiconterm` and `otherterm`, but according to the description it should be `diagnostendum term` (this is split out in GOLD and article (free) term, but here it is combined into one) and `other term`.
- How do we want to order the form?
- Empty annotations are broken now but they should work again after merging #39 
- It seems there are some problems with opening existing annotations that have no data on all fields...