### PR TITLE
Feature/disable

### DIFF
--- a/bootstrap.js
+++ b/bootstrap.js
@@ -5,6 +5,7 @@ var stylesheetID = 'lidia-stylesheet';
 var ftlID = 'lidia-ftl';
 var menuitemID = 'lidia-about';
 var addedElementIDs = [stylesheetID, ftlID, menuitemID];
+var extensionScope;
 
 if (typeof Zotero == 'undefined') {
 	var Zotero;
@@ -154,21 +155,23 @@ async function startup({ id, version, resourceURI, rootURI = resourceURI.spec })
 
 	// Load out.js with the Zotero main window as its scope to make the
 	// window object globally available
-	const scope = Zotero.getMainWindow();
-	Services.scriptloader.loadSubScript(rootURI + 'out.js', scope);
+	extensionScope = Zotero.getMainWindow();
+	Services.scriptloader.loadSubScript(rootURI + 'out.js', extensionScope);
 
 	// Add functions from bootstrap.js to scope to make them available
 	// TODO: move these functions to lib.js
-	scope.log = log;
-	scope.getString = getString;
-	scope.createHElement = createHElement;
-	scope.createXElement = createXElement;
+	extensionScope.log = log;
+	extensionScope.getString = getString;
+	extensionScope.createHElement = createHElement;
+	extensionScope.createXElement = createXElement;
 
-	await scope.Lidia.init(rootURI);
+	await extensionScope.Lidia.init(rootURI);
 }
 
 function shutdown() {
 	log("Shutting down...");
+
+	extensionScope.Lidia.shutdown();
 
 	// Remove stylesheet
 	var zp = Zotero.getActiveZoteroPane();

--- a/build.mjs
+++ b/build.mjs
@@ -19,6 +19,7 @@ async function build() {
         bundle: true,
         loader: { '.js': 'jsx' },
         outfile: 'build/out.js',
+        target: 'es2015',
     });
     await fs.copy('bootstrap.js', 'build/bootstrap.js');
 }

--- a/src/lib.js
+++ b/src/lib.js
@@ -73,4 +73,9 @@ window.Lidia = {
             * the selected annotation was automatically activated. */
         this.panel.disablePanel(undefined);
     },
+
+    shutdown: function() {
+        this.panel.destroy();
+        Zotero.Notifier.unregisterObserver(this.notifierID);
+    }
 };

--- a/src/lib.js
+++ b/src/lib.js
@@ -57,6 +57,13 @@ window.Lidia = {
         ]);
 
         this.panel = new LidiaPanel();
+
+        // If a reader is currently selected, activate it. This is only needed
+        // when a user activates the extension while Zotero is running.
+        const reader = Zotero.Reader.getByTabID(window.Zotero_Tabs._selectedID);
+        if (reader) {
+            this.onReaderSelect(reader);
+        }
     },
 
     onReaderSelect: async function(reader) {

--- a/src/panel.js
+++ b/src/panel.js
@@ -14,6 +14,10 @@ import { getAllLidiaAnnotations } from "./relations.js";
  * as a whole - this panel is shared between Zotero tabs.
  */
 export class LidiaPanel {
+    tab;
+    tabPanel;
+    annotationEvents = [];
+
     /**
      * Create a LidiaPanel object. Can be called as soon as the Zotero main
      * window is ready. Does not yet build the panel UI.
@@ -95,6 +99,15 @@ export class LidiaPanel {
                             onSave={this.onSaveAnnotation.bind(this)}
                             annotations={annotations}
                         />);
+    }
+
+    destroy() {
+        for (const event of this.annotationEvents) {
+            event.element.removeEventListener("click", event.callback);
+            event.element.setAttribute("lidiainit", "false");
+        }
+        this.tab.remove();
+        this.tabPanel.remove();
     }
 
     /**
@@ -237,9 +250,13 @@ export class LidiaPanel {
                 itemKey
             );
 
-            annotation.addEventListener("click", (e) => {
+            const callback = (e) => {
                 this.onAnnotationActivated(annotationItem, true);
                 e.preventDefault();
+            };
+            annotation.addEventListener("click", callback);
+            this.annotationEvents.push({
+                element: annotation, callback: callback
             });
         }
     }

--- a/src/panel.js
+++ b/src/panel.js
@@ -106,8 +106,12 @@ export class LidiaPanel {
             event.element.removeEventListener("click", event.callback);
             event.element.setAttribute("lidiainit", "false");
         }
-        this.tab.remove();
-        this.tabPanel.remove();
+        if (this.tab) {
+            this.tab.remove();
+        }
+        if (this.tabPanel) {
+            this.tabPanel.remove();
+        }
     }
 
     /**


### PR DESCRIPTION
Revert all UI changes on shutdown of the extension. I tested to make sure that the extension can be re-activated again without problems.

It may be that Zotero.Lidia is still available after deactivation, but it will be replaced with a new object after re-activation.

I also added `target: "es2015"` to `build.mjs` because I had accidentally introduced newer syntax that made that out.js did not load, and of course there was no error message...