### PR TITLE
Fix relation bug

### DIFF
--- a/src/relations.js
+++ b/src/relations.js
@@ -38,7 +38,7 @@ export async function getAllLidiaAnnotations(libraryID) {
                                 annotationObj.argcont !== true
                             ) {
                                 annotationObj.documentTitle = item.getField('title')
-                                annotationObj.zoteroKey = item.key;
+                                annotationObj.zoteroKey = annotation.key;
                                 lidiaAnnotations.push(annotationObj);
                             }
                         }


### PR DESCRIPTION
By mistake, `relations.js` added the key of the parent item of each annotation to the annotation objects. This is fixed now.

Closes #48.