### PR TITLE
Implement autosave

### DIFF
--- a/src/components/TermGroup.js
+++ b/src/components/TermGroup.js
@@ -4,9 +4,7 @@ import lexiconTerms from '../../content/lexicon.json';
 
 const TermGroup = ({ value, onChange }) => {
     // Set default value - cleaner way possible?
-    if (typeof(value) === "undefined") {
-        value = {};
-    }
+    value = value || {};
     if (!value.lexiconterm) {
         value.lexiconterm = '';
     }

--- a/src/components/TermGroup.js
+++ b/src/components/TermGroup.js
@@ -4,6 +4,9 @@ import lexiconTerms from '../../content/lexicon.json';
 
 const TermGroup = ({ value, onChange }) => {
     // Set default value - cleaner way possible?
+    if (typeof(value) === "undefined") {
+        value = {};
+    }
     if (!value.lexiconterm) {
         value.lexiconterm = '';
     }


### PR DESCRIPTION
Save automatically every 1000 ms and whenever a new annotation is selected. This seems to work fine with db saving and syncing. It is a bit tricky however and I had to make some further changes. One tricky part was that this was first also saving new annotations (with an empty comment field), which would be unwanted if a user selects an annotation for another reason.

I have removed the "data will be overridden" check because it doesn't make sense if changed are saved automatically - instead I have added a warning to the checkbox. It is still possible to revert the existing data as long as you don't select a new annotation, though.